### PR TITLE
V9 compatibility

### DIFF
--- a/img/lv_tc_indicator_img.c
+++ b/img/lv_tc_indicator_img.c
@@ -74,10 +74,8 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMG_LV_TC_IND
   0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 };
 
-const lv_img_dsc_t lv_tc_indicator_img = {
-  .header.cf = LV_IMG_CF_ALPHA_2BIT,
-  .header.always_zero = 0,
-  .header.reserved = 0,
+const lv_image_dsc_t lv_tc_indicator_img = {
+  .header.cf = LV_COLOR_FORMAT_A2,
   .header.w = 50,
   .header.h = 50,
   .data_size = 650,

--- a/lv_tc.c
+++ b/lv_tc.c
@@ -19,7 +19,7 @@
  *  STATIC PROTOTYPES
  **********************/
 
-static void lv_tc_indev_drv_read_cb(lv_indev_drv_t *indevDrv, lv_indev_data_t *data);
+static void lv_tc_indev_read_cb(lv_indev_t *indev, lv_indev_data_t *data);
 
 
 /**********************
@@ -37,11 +37,9 @@ static void (*registeredSaveCb)(lv_tc_coeff_t coeff) = NULL;
  *   GLOBAL FUNCTIONS
  **********************/
 
-void lv_tc_indev_drv_init(lv_indev_drv_t *indevDrv, void (*readCb)(lv_indev_drv_t *indevDrv, lv_indev_data_t *data)) {
-    lv_indev_drv_init(indevDrv);
-    indevDrv->type = LV_INDEV_TYPE_POINTER;
-    indevDrv->read_cb = lv_tc_indev_drv_read_cb;
-    indevDrv->user_data = readCb;
+void lv_tc_indev_init(lv_indev_t *indev) {
+    lv_indev_set_user_data(indev, (void*)lv_indev_get_read_cb(indev));
+    lv_indev_set_read_cb(indev, lv_tc_indev_read_cb);
 }
 
 void _lv_tc_register_input_cb(lv_obj_t *screenObj, bool (*inputCb)(lv_obj_t *screenObj, lv_indev_data_t *data)) {
@@ -165,11 +163,11 @@ lv_point_t lv_tc_transform_point(lv_point_t point) {
  *   STATIC FUNCTIONS
  **********************/
 
-static void lv_tc_indev_drv_read_cb(lv_indev_drv_t *indevDrv, lv_indev_data_t *data) {
-    if(!indevDrv->user_data) return;
+static void lv_tc_indev_read_cb(lv_indev_t *indev, lv_indev_data_t *data) {
+    if(!lv_indev_get_user_data(indev)) return;
 
     //Call the actual indev read callback
-    ((void (*)(lv_indev_drv_t*, lv_indev_data_t*))indevDrv->user_data)(indevDrv, data);
+    ((void (*)(lv_indev_t*, lv_indev_data_t*))lv_indev_get_user_data(indev))(indev, data);
 
     //Pass the results to an ongoing calibration if there is one
     if(registeredTCScreen && registeredInputCb && registeredTCScreen == lv_scr_act()) {

--- a/lv_tc.h
+++ b/lv_tc.h
@@ -35,14 +35,17 @@ typedef struct {
  **********************/
 
 /**
- * Initialize a calibrated touch input driver.
- * @param indevDrv pointer to an input driver
- * @param readCb function pointer to read input driver data
+ * Initialize a calibrated touch input device.
+ * As of LVGL version 9.0 the device setup is done outside this function.
+ * It expects a read callback already set.
+ * Also uses its user data field. DO NOT OVERRIDE
+ * @param indev pointer to an input device
  */
-void lv_tc_indev_drv_init(lv_indev_drv_t *indevDrv, void (*readCb)(struct _lv_indev_drv_t *indevDrv, lv_indev_data_t *data));
+void lv_tc_indev_init(lv_indev_t *indev);
+
 
 /**
- * Register a calibration screen to the modified input driver.
+ * Register a calibration screen to the modified input device.
  * NOT TO BE CALLED IN APPLICATION CODE
  * @param screenObj pointer to the screen object
  * @param inputCb function pointer to handle the input

--- a/lv_tc_screen.c
+++ b/lv_tc_screen.c
@@ -132,10 +132,12 @@ static void lv_tc_screen_constructor(const lv_obj_class_t *class_p, lv_obj_t *ob
     lv_obj_clear_flag(obj, LV_OBJ_FLAG_SCROLLABLE);
 
 
-    LV_IMG_DECLARE(lv_tc_indicator_img);
+    LV_IMAGE_DECLARE(lv_tc_indicator_img);
 
-    tCScreenObj->indicatorObj = lv_img_create(obj);
-    lv_img_set_src(tCScreenObj->indicatorObj, &lv_tc_indicator_img);
+    tCScreenObj->indicatorObj = lv_image_create(obj);
+    lv_image_set_src(tCScreenObj->indicatorObj, &lv_tc_indicator_img);
+    lv_obj_set_style_image_recolor_opa(tCScreenObj->indicatorObj, LV_OPA_COVER, 0);
+    lv_obj_set_style_image_recolor(tCScreenObj->indicatorObj, lv_color_black(), 0);
     lv_obj_clear_flag(tCScreenObj->indicatorObj, LV_OBJ_FLAG_CLICKABLE);
 
 
@@ -168,14 +170,17 @@ static void lv_tc_screen_constructor(const lv_obj_class_t *class_p, lv_obj_t *ob
 
 static void lv_tc_screen_auto_set_points(lv_obj_t *screenObj) {
     //Choose the on-screen calibration points based on the active display driver's resolution
-    lv_coord_t marginH = lv_disp_get_default()->driver->hor_res * 0.15;
-    lv_coord_t marginV = lv_disp_get_default()->driver->ver_res * 0.15;
-    lv_coord_t margin = (marginH < marginV) ? marginH: marginV;
+    int32_t horRes = lv_display_get_horizontal_resolution(lv_display_get_default());
+    int32_t verRes = lv_display_get_vertical_resolution(lv_display_get_default());
+    
+    int32_t marginH = horRes * 0.15;
+    int32_t marginV = verRes * 0.15;
+    int32_t margin = (marginH < marginV) ? marginH: marginV;
 
     lv_point_t points[3] = {
-        {       margin                                         , (float)lv_disp_get_default()->driver->ver_res * 0.3   },
-        {(float)lv_disp_get_default()->driver->hor_res * 0.4   ,        lv_disp_get_default()->driver->ver_res - margin},
-        {       lv_disp_get_default()->driver->hor_res - margin,        margin                                         }
+        {       margin         , (float)verRes * 0.3   },
+        {(float)horRes * 0.4   ,        verRes - margin},
+        {       horRes - margin,        margin         }
     };
     lv_tc_screen_set_points(screenObj, points);
 }


### PR DESCRIPTION
Change the input device interface to accept the new indev_t type. The setup sequence now modifies an existing input device instead of fully configuring a new one. See the updated [README](https://github.com/jakpaul/lvgl_touch_calibration/tree/v9-compatibility?tab=readme-ov-file#firmware-setup) for details. Also modify cal-point selection code around changed display API and the cursor image.